### PR TITLE
Fix gitignore for Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-snmp/.vagrant/
+.vagrant/
 
 .history/


### PR DESCRIPTION
All temporary directories created by `vagrant up` should be ignored by git.
